### PR TITLE
adding tag to phusion/baseimage to solve manifest unknown error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Chose this ubuntu base image because its small and optimized for Docker(ness)
-FROM phusion/baseimage
+FROM phusion/baseimage:latest-amd64
 
 # Installing what I need from ubuntu to do the job.
 # - wget to download stuff from the web


### PR DESCRIPTION
…nifest unknown

I get this error when trying to build the container:
`manifest for phusion/baseimage:latest not found: manifest unknown: manifest unknown`

Adding the tag :latest-amd64 to the phusion/baseimage seems to solve this.